### PR TITLE
Reliability fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,28 @@ Incident and alert management tool which plays a role of and additional on-call 
 
 ### Click to watch the demo
 [<img src="https://signaloneai.com/online-assets/signal0ne_thumbnail.png" width="50%">](https://www.loom.com/share/b0b67a6750634a89a204122668db1412?sid=86565b92-bf22-4af2-ab20-12e6236b5a85)
+
+
+# LICENSE
+
+MIT License
+
+Copyright (c) 2024 Signal0ne
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/backend/internal/controllers/alert.controller.go
+++ b/backend/internal/controllers/alert.controller.go
@@ -109,10 +109,7 @@ func (ac *AlertController) SyncCorrelateAlertsFromDiffSources(ctx *gin.Context, 
 			if ongoingAlertsOutput == nil {
 				return fmt.Errorf("output not found for step %s", step.Name)
 			}
-			for _, alertOutput := range ongoingAlertsOutput {
-				dependencyMap += "," + alertOutput.(map[string]any)["dependency_map"].(string)
-
-			}
+			dependencyMap += ongoingAlertsOutput[0].(map[string]any)["dependency_map"].(string)
 
 			switch step.Integration {
 			case "signal0ne":

--- a/backend/internal/controllers/alert.controller.go
+++ b/backend/internal/controllers/alert.controller.go
@@ -107,7 +107,6 @@ func (ac *AlertController) SyncCorrelateAlertsFromDiffSources(ctx *gin.Context, 
 
 			ongoingAlertsOutput, _ := alert.AdditionalContext[fmt.Sprintf("%s_%s", step.Integration, step.Name)].(bson.A)
 			if ongoingAlertsOutput == nil {
-				fmt.Printf("output not found for step xyz %s", step.Name)
 				return fmt.Errorf("output not found for step %s", step.Name)
 			}
 			for _, alertOutput := range ongoingAlertsOutput {

--- a/backend/internal/controllers/incident.controller.go
+++ b/backend/internal/controllers/incident.controller.go
@@ -291,6 +291,7 @@ func (ic *IncidentController) CreateIncident(ctx *gin.Context) {
 
 	default: //signal0ne is the default
 		inventory := signal0ne.NewSignal0neIntegrationInventory(
+			ic.AlertsCollection,
 			ic.IncidentsCollection,
 			ic.PyInterface,
 			&workflow,

--- a/backend/internal/controllers/workflow.controller.go
+++ b/backend/internal/controllers/workflow.controller.go
@@ -458,7 +458,12 @@ func (c *WorkflowController) WebhookTriggerHandler(ctx *gin.Context) {
 				Inventory: inventory,
 			}
 		case "openai":
-			integration = &openai.OpenaiIntegration{}
+			inventory := openai.NewOpenAIIntegrationInventory(
+				c.AlertsCollection,
+			)
+			integration = &openai.OpenaiIntegration{
+				Inventory: inventory,
+			}
 		case "opensearch":
 			inventory := opensearch.NewOpenSearchIntegrationInventory(
 				c.PyInterface,

--- a/backend/internal/controllers/workflow.controller.go
+++ b/backend/internal/controllers/workflow.controller.go
@@ -280,6 +280,7 @@ func (c *WorkflowController) WebhookTriggerHandler(ctx *gin.Context) {
 		Id:                primitive.NewObjectID(),
 		TriggerProperties: map[string]any{},
 		AdditionalContext: map[string]any{},
+		Tags:              []string{},
 	}
 
 	namespaceId := ctx.Param("namespaceid")
@@ -501,7 +502,6 @@ func (c *WorkflowController) WebhookTriggerHandler(ctx *gin.Context) {
 
 		err = result.Decode(integration)
 		if err != nil {
-			fmt.Printf("integration schema parsing error, %s", err)
 			localErrorMessage = fmt.Sprintf("%v", err)
 			continue
 		}
@@ -628,6 +628,13 @@ func (c *WorkflowController) WebhookTriggerHandler(ctx *gin.Context) {
 
 		if execResult != nil {
 			alert.AdditionalContext[fmt.Sprintf("%s_%s", integrationTemplate.Name, step.Name)] = execResult
+			for _, resultObject := range execResult {
+				for key, value := range resultObject {
+					if key == "tags" {
+						alert.Tags = append(alert.Tags, value.([]string)...)
+					}
+				}
+			}
 			executionLog.Outputs[step.Name] = execResult
 		}
 

--- a/backend/internal/controllers/workflow.controller.go
+++ b/backend/internal/controllers/workflow.controller.go
@@ -415,14 +415,12 @@ func (c *WorkflowController) WebhookTriggerHandler(ctx *gin.Context) {
 		result := c.IntegrationsCollection.FindOne(ctx, filter)
 		err := result.Decode(&integrationTemplate)
 		if err != nil {
-			fmt.Printf("integration schema parsing error, %s", err)
 			localErrorMessage = fmt.Sprintf("%v", err)
 			continue
 		}
 
 		_, exists := integrations.InstallableIntegrationTypesLibrary[integrationTemplate.Type]
 		if !exists {
-			fmt.Printf("cannot find integration type specified")
 			localErrorMessage = fmt.Sprintf("%v", err)
 			continue
 		}
@@ -623,8 +621,10 @@ func (c *WorkflowController) WebhookTriggerHandler(ctx *gin.Context) {
 				execResult)
 		}
 
-		alert.AdditionalContext[fmt.Sprintf("%s_%s", integrationTemplate.Name, step.Name)] = execResult
-		executionLog.Outputs[step.Name] = execResult
+		if execResult != nil {
+			alert.AdditionalContext[fmt.Sprintf("%s_%s", integrationTemplate.Name, step.Name)] = execResult
+			executionLog.Outputs[step.Name] = execResult
+		}
 
 		status := "success"
 		if localErrorMessage != "" {

--- a/backend/internal/db/alert.go
+++ b/backend/internal/db/alert.go
@@ -41,7 +41,9 @@ func GetEnrichedAlertsByWorkflowId(
 ) ([]models.EnrichedAlert, error) {
 	var alerts []models.EnrichedAlert
 
-	filter["workflowId"] = workflowId
+	if workflowId != "" {
+		filter["workflowId"] = workflowId
+	}
 
 	cursor, err := alertsCollection.Find(ctx, filter)
 	if err == mongo.ErrNoDocuments {

--- a/backend/internal/errors/errors.go
+++ b/backend/internal/errors/errors.go
@@ -1,0 +1,6 @@
+package errors
+
+import "fmt"
+
+var ErrConditionNotSatisfied = fmt.Errorf("condition not satisfied")
+var ErrAlertAlreadyInactive = fmt.Errorf("alert already inactive")

--- a/backend/internal/models/alert.go
+++ b/backend/internal/models/alert.go
@@ -9,7 +9,7 @@ import (
 type AlertStatus string
 
 const (
-	AlertStatusActive   AlertStatus = "active"
+	AlertStatusActive   AlertStatus = "open"
 	AlertStatusInactive AlertStatus = "inactive"
 )
 

--- a/backend/internal/models/alert.go
+++ b/backend/internal/models/alert.go
@@ -19,6 +19,7 @@ type EnrichedAlert struct {
 	AlertName         string             `json:"alertName" bson:"alertName"`
 	Integration       string             `json:"integration" bson:"integration"`
 	OriginalUrl       string             `json:"originalUrl" bson:"originalUrl"`
+	Tags              []string           `json:"tags" bson:"tags"`
 	StartTime         time.Time          `json:"startTime" bson:"startTime"`
 	State             AlertStatus        `json:"state" bson:"state"`
 	Service           string             `json:"service" bson:"service"`

--- a/backend/internal/models/alert.go
+++ b/backend/internal/models/alert.go
@@ -1,6 +1,10 @@
 package models
 
-import "go.mongodb.org/mongo-driver/bson/primitive"
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
 
 type AlertStatus string
 
@@ -15,8 +19,9 @@ type EnrichedAlert struct {
 	AlertName         string             `json:"alertName" bson:"alertName"`
 	Integration       string             `json:"integration" bson:"integration"`
 	OriginalUrl       string             `json:"originalUrl" bson:"originalUrl"`
-	StartTime         string             `json:"startTime" bson:"startTime"`
+	StartTime         time.Time          `json:"startTime" bson:"startTime"`
 	State             AlertStatus        `json:"state" bson:"state"`
+	Service           string             `json:"service" bson:"service"`
 	TriggerProperties map[string]any     `json:"triggerProperties,inline" bson:"triggerProperties,inline"`
 	WorkflowId        string             `json:"workflowId" bson:"workflowId"`
 }

--- a/backend/internal/models/trigger.go
+++ b/backend/internal/models/trigger.go
@@ -12,6 +12,7 @@ type WebhookTrigger struct {
 type Webhook struct {
 	Output      map[string]string `json:"output"`
 	Integration string            `json:"integration"`
+	Service     string            `json:"service"`
 	Condition   string            `json:"condition"`
 }
 

--- a/backend/internal/tools/flowexec.go
+++ b/backend/internal/tools/flowexec.go
@@ -142,7 +142,14 @@ func ExecutionResultWrapper(intermediateResults []any,
 	for _, result := range intermediateResults {
 		var traverseResult = map[string]any{}
 		for key, mapping := range output {
-			traverseResult[key] = TraverseOutput(result, key, mapping)
+			mappings := strings.Split(mapping, ",")
+			for _, localMapping := range mappings {
+				localMapping = strings.TrimSpace(localMapping)
+				traverseResult[key] = TraverseOutput(result, key, localMapping)
+				if traverseResult[key] != nil {
+					break
+				}
+			}
 		}
 		traverseResult["tags"] = outputTags
 		results = append(results, traverseResult)

--- a/backend/internal/utils/general.helpers.go
+++ b/backend/internal/utils/general.helpers.go
@@ -15,3 +15,12 @@ func GenerateRandomString() string {
 
 	return string(bytes)
 }
+
+func Contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/utils/general.helpers.go
+++ b/backend/internal/utils/general.helpers.go
@@ -24,3 +24,14 @@ func Contains(slice []string, item string) bool {
 	}
 	return false
 }
+
+func UnpackDependencyMap(dependencyMap map[string]any, services *[]string) {
+	for service, children := range dependencyMap {
+		if !Contains(*services, service) {
+			*services = append(*services, service)
+		}
+		if children != nil {
+			UnpackDependencyMap(children.(map[string]any), services)
+		}
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -85,6 +85,7 @@ func main() {
 
 	alertController := controllers.NewAlertController(alertsCollection,
 		incidentsCollection,
+		integrationsCollection,
 		conn,
 		workflowsCollection)
 	mainController := controllers.NewMainController()

--- a/backend/main.go
+++ b/backend/main.go
@@ -83,7 +83,10 @@ func main() {
 		})
 	})
 
-	alertController := controllers.NewAlertController(alertsCollection)
+	alertController := controllers.NewAlertController(alertsCollection,
+		incidentsCollection,
+		conn,
+		workflowsCollection)
 	mainController := controllers.NewMainController()
 	namespaceController := controllers.NewNamespaceController(namespacesCollection, usersCollection)
 	workflowController := controllers.NewWorkflowController(

--- a/backend/pkg/integrations/.assets/metadata/github.yaml
+++ b/backend/pkg/integrations/.assets/metadata/github.yaml
@@ -3,3 +3,4 @@ name: GitHub
 imageUri: ../logos/github.svg
 config:
   apiKey: secret
+  url: string

--- a/backend/pkg/integrations/confluence/confluence_integration.go
+++ b/backend/pkg/integrations/confluence/confluence_integration.go
@@ -17,7 +17,7 @@ var functions = map[string]models.WorkflowFunctionDefinition{
 	"search": models.WorkflowFunctionDefinition{
 		Function:   search,
 		Input:      SearchInput{},
-		OutputTags: []string{"runbooks"},
+		OutputTags: []string{"docs"},
 	},
 }
 

--- a/backend/pkg/integrations/github/config.go
+++ b/backend/pkg/integrations/github/config.go
@@ -2,4 +2,5 @@ package github
 
 type Config struct {
 	ApiKey string `json:"apiKey" bson:"apiKey"`
+	Url    string `json:"url" bson:"url"`
 }

--- a/backend/pkg/integrations/github/github_integration.go
+++ b/backend/pkg/integrations/github/github_integration.go
@@ -17,19 +17,24 @@ import (
 
 type GithubIntegration struct {
 	models.Integration `json:",inline" bson:",inline"`
-	Config             `json:",inline" bson:",inline"`
+	Config             `json:"config" bson:"config"`
 }
 
 var functions = map[string]models.WorkflowFunctionDefinition{
 	"get_content": models.WorkflowFunctionDefinition{
 		Function:   getContent,
 		Input:      GetFileContentInput{},
-		OutputTags: []string{"metdata", "logs"},
+		OutputTags: []string{"metadata", "logs"},
 	},
 	"get_commit_diff": models.WorkflowFunctionDefinition{
 		Function:   getCommitDiff,
 		Input:      GetCommitDiff{},
-		OutputTags: []string{"metdata", "code"},
+		OutputTags: []string{"metadata", "code"},
+	},
+	"inspect_github_actions": models.WorkflowFunctionDefinition{
+		Function:   inspectGithubActions,
+		Input:      InspectGithubActionsInput{},
+		OutputTags: []string{"metadata"},
 	},
 }
 
@@ -84,14 +89,20 @@ func (integration GithubIntegration) ValidateStep(
 }
 
 type GetCommitDiff struct {
-	Commit  string `json:"commit" bson:"commit"`
-	RepoUri string `json:"repo_uri" bson:"repo_uri"`
+	Commit   string `json:"commit" bson:"commit"`
+	RepoName string `json:"repo_name" bson:"repo_name"`
 }
 
 type GetFileContentInput struct {
 	ContentUrl string `json:"content_url" bson:"content_url"`
 	Path       string `json:"path" bson:"path"`
 	Type       string `json:"type" bson:"type"`
+}
+
+type InspectGithubActionsInput struct {
+	ActionName string `json:"action_name" bson:"action_name"`
+	BranchName string `json:"branch_name" bson:"branch_name"`
+	RepoName   string `json:"repo_name" bson:"repo_name"`
 }
 
 func getCommitDiff(input any, integration any) ([]any, error) {
@@ -103,15 +114,15 @@ func getCommitDiff(input any, integration any) ([]any, error) {
 		return output, err
 	}
 
-	parsedIntegration := integration.(GithubIntegration)
+	assertedIntegration := integration.(GithubIntegration)
 
-	//Get commit id from github action deployment
 	commitId := parsedInput.Commit
 
-	repoUriDecomposed := strings.Split(parsedInput.RepoUri, "/")
-	repo := fmt.Sprintf("%s/%s", repoUriDecomposed[len(repoUriDecomposed)-2], repoUriDecomposed[len(repoUriDecomposed)-1])
+	assertedIntegration.Config.Url = strings.TrimSuffix(assertedIntegration.Config.Url, "/")
+	decomposedUri := strings.Split(assertedIntegration.Config.Url, "/")
+	org := decomposedUri[len(decomposedUri)-1]
 
-	url := fmt.Sprintf("https://api.github.com/repos/%s/commits/%s", repo, commitId)
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/commits/%s", org, parsedInput.RepoName, commitId)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return output, err
@@ -120,7 +131,7 @@ func getCommitDiff(input any, integration any) ([]any, error) {
 	req.Header.Set("Accept", "application/vnd.github.diff")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	req.Header.Set("Authorization",
-		fmt.Sprintf("Bearer %s", parsedIntegration.ApiKey),
+		fmt.Sprintf("Bearer %s", assertedIntegration.Config.ApiKey),
 	)
 
 	client := &http.Client{}
@@ -183,6 +194,76 @@ func getContent(input any, integration any) ([]any, error) {
 
 	output = append(output, map[string]any{
 		"content": content,
+	})
+
+	return output, nil
+}
+
+func inspectGithubActions(input any, integration any) ([]any, error) {
+	var parsedInput InspectGithubActionsInput
+	var output []any
+
+	err := helpers.ValidateInputParameters(input, &parsedInput, "inspect_github_actions")
+	if err != nil {
+		return output, err
+	}
+
+	assertedIntegration := integration.(GithubIntegration)
+
+	assertedIntegration.Config.Url = strings.TrimSuffix(assertedIntegration.Config.Url, "/")
+	decomposedUri := strings.Split(assertedIntegration.Config.Url, "/")
+	org := decomposedUri[len(decomposedUri)-1]
+
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/actions/runs", org, parsedInput.RepoName)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return output, err
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Authorization",
+		fmt.Sprintf("Bearer %s", assertedIntegration.Config.ApiKey),
+	)
+
+	client := &http.Client{}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return output, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return output, fmt.Errorf("failed to get GitHub actions: %s", resp.Status)
+	}
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return output, err
+	}
+
+	var actionsResponse map[string]any
+	err = json.Unmarshal(responseBody, &actionsResponse)
+	if err != nil {
+		return output, err
+	}
+
+	actionRuns, ok := actionsResponse["workflow_runs"].([]any)
+	if !ok {
+		return output, fmt.Errorf("cannot parse GitHub actions")
+	}
+
+	latestAction, ok := actionRuns[0].(map[string]any)
+	if !ok {
+		return output, fmt.Errorf("cannot parse GitHub actions")
+	}
+
+	output = append(output, map[string]any{
+		"status":     latestAction["conclusion"],
+		"commit":     latestAction["head_sha"],
+		"created_at": latestAction["created_at"],
+		"url":        latestAction["html_url"],
 	})
 
 	return output, nil

--- a/backend/pkg/integrations/github/github_integration.go
+++ b/backend/pkg/integrations/github/github_integration.go
@@ -26,6 +26,11 @@ var functions = map[string]models.WorkflowFunctionDefinition{
 		Input:      GetFileContentInput{},
 		OutputTags: []string{"metdata", "logs"},
 	},
+	"get_commit_diff": models.WorkflowFunctionDefinition{
+		Function:   getCommitDiff,
+		Input:      GetCommitDiff{},
+		OutputTags: []string{"metdata", "code"},
+	},
 }
 
 func (integration GithubIntegration) Execute(
@@ -78,10 +83,27 @@ func (integration GithubIntegration) ValidateStep(
 	return nil
 }
 
+type GetCommitDiff struct {
+}
+
 type GetFileContentInput struct {
 	ContentUrl string `json:"content_url" bson:"content_url"`
 	Path       string `json:"path" bson:"path"`
 	Type       string `json:"type" bson:"type"`
+}
+
+func getCommitDiff(input any, integration any) ([]any, error) {
+	var parsedInput GetFileContentInput
+	var output []any
+
+	err := helpers.ValidateInputParameters(input, &parsedInput, "get_commit_diff")
+	if err != nil {
+		return output, err
+	}
+
+	_ = integration.(GithubIntegration)
+
+	return output, nil
 }
 
 func getContent(input any, integration any) ([]any, error) {

--- a/backend/pkg/integrations/github/github_integration.go
+++ b/backend/pkg/integrations/github/github_integration.go
@@ -29,7 +29,7 @@ var functions = map[string]models.WorkflowFunctionDefinition{
 	"get_commit_diff": models.WorkflowFunctionDefinition{
 		Function:   getCommitDiff,
 		Input:      GetCommitDiff{},
-		OutputTags: []string{"metadata", "code"},
+		OutputTags: []string{"code", "metadata"},
 	},
 	"inspect_github_actions": models.WorkflowFunctionDefinition{
 		Function:   inspectGithubActions,

--- a/backend/pkg/integrations/jaeger/jaeger_integration.go
+++ b/backend/pkg/integrations/jaeger/jaeger_integration.go
@@ -284,6 +284,7 @@ func compareTraces(input any, integration any) ([]any, error) {
 		finalUrl = fmt.Sprintf("%s%s", url, apiPath)
 
 		operations, err = getJaegerObjects(finalUrl)
+		fmt.Printf("operations: %v\n", operations)
 		if err != nil {
 			return output, err
 		}
@@ -350,15 +351,16 @@ func compareTraces(input any, integration any) ([]any, error) {
 
 		processesDiffSlice := diffStringSlices(baseProcessesSlice, comparedProcessesSlice)
 
+		diff.DependencyMap = fmt.Sprintf("%s\n", parsedInput.Service)
+		for pid, process := range baseProcessesSlice {
+			spacing := strings.Repeat("-", (pid+1)*2)
+			diff.DependencyMap += fmt.Sprintf("%s%s\n", spacing, process)
+
+		}
+
 		if len(processesDiffSlice) > 0 {
 			diff.Processes = strings.Join(processesDiffSlice, ",")
 			diff.Operation = operation.(string)
-			diff.DependencyMap = fmt.Sprintf("%s\n", parsedInput.Service)
-			for pid, process := range baseProcessesSlice {
-				spacing := strings.Repeat("-", (pid+1)*2)
-				diff.DependencyMap += fmt.Sprintf("%s%s\n", spacing, process)
-
-			}
 			diff.Spans = "" //TODO: Implement spans comparison
 			translatedMap := map[string]any{
 				"dependency_map": diff.DependencyMap,

--- a/backend/pkg/integrations/jaeger/jaeger_integration_test.go
+++ b/backend/pkg/integrations/jaeger/jaeger_integration_test.go
@@ -1,0 +1,35 @@
+package jaeger
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_GetDependencies tests the function getDependencies
+
+// You need to run lab01
+// In order to run this test without mocking
+func Test_GetDependencies(t *testing.T) {
+
+	mockedGetDependenciesInput := map[string]string{
+		"service": "adservice",
+	}
+
+	inventory := NewJaegerIntegrationInventory(nil)
+	integration := JaegerIntegration{
+		Inventory: inventory,
+		Config: Config{
+			Url: "http://20.127.192.216:16686",
+		},
+	}
+
+	output, err := getDependencies(mockedGetDependenciesInput, integration)
+
+	fmt.Printf("output: %v\n", output)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, output)
+
+}

--- a/backend/pkg/integrations/openai/openai_integration.go
+++ b/backend/pkg/integrations/openai/openai_integration.go
@@ -2,26 +2,38 @@ package openai
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"signal0ne/internal/db"
 	"signal0ne/internal/models"
 	"signal0ne/internal/tools"
 	"signal0ne/pkg/integrations/helpers"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/mongo"
 )
+
+type OpenAIIntegrationInventory struct {
+	AlertsCollection *mongo.Collection `json:"-" bson:"-"`
+}
+
+func NewOpenAIIntegrationInventory(
+	alertsCollection *mongo.Collection) OpenAIIntegrationInventory {
+	return OpenAIIntegrationInventory{
+		AlertsCollection: alertsCollection,
+	}
+}
 
 type OpenaiIntegration struct {
 	models.Integration `json:",inline" bson:",inline"`
 	Config             `json:"config" bson:"config"`
+	Inventory          OpenAIIntegrationInventory
 }
 
 var functions = map[string]models.WorkflowFunctionDefinition{
-	"propose_resolution_steps": models.WorkflowFunctionDefinition{
-		Function:   proposeResolutions,
-		Input:      ProposeResolutionsInput{},
-		OutputTags: []string{"copilot"},
-	},
 	"summarize_context": models.WorkflowFunctionDefinition{
 		Function:   summarizeContext,
 		Input:      SummarizeContextInput{},
@@ -83,45 +95,18 @@ type SummarizeContextInput struct {
 	Context string `json:"context"`
 }
 
-type ProposeResolutionsInput struct {
-	AdditionalContext string `json:"additional_context"`
-	Logs              string `json:"logs"`
-}
-
-func proposeResolutions(input any, integration any) ([]any, error) {
-	var parsedInput ProposeResolutionsInput
-	var output []any
-
-	err := helpers.ValidateInputParameters(input, &parsedInput, "propose_resolution_steps")
-	if err != nil {
-		return output, err
-	}
-
-	assertedIntegration := integration.(OpenaiIntegration)
-
-	fmt.Printf("###\nExecuting OpenAi integration function...\n")
-	model := assertedIntegration.Model
-	apiKey := assertedIntegration.ApiKey
-	prompt := fmt.Sprintf(`You are on-call engineer Based on the logs and additional context like documentation or runbooks propose resolutions.
-		Response must contain up to 3 steps with resolutions.
-		Logs: %s
-		Additional Context %s`, parsedInput.Logs, parsedInput.AdditionalContext)
-
-	resolutions, err := callOpenAiApi(prompt, model, apiKey)
-	if err != nil {
-		return output, err
-	}
-
-	output = append(output, map[string]any{
-		"content": resolutions,
-	})
-
-	return output, nil
-}
-
 func summarizeContext(input any, integration any) ([]any, error) {
 	var parsedInput SummarizeContextInput
 	var output []any
+	var alertContext models.EnrichedAlert
+	var partialSummaries = make([]string, 0)
+
+	var tagContextGroups = map[string][]map[string]any{
+		"code":     make([]map[string]any, 0),
+		"logs":     make([]map[string]any, 0),
+		"alerts":   make([]map[string]any, 0),
+		"metadata": make([]map[string]any, 0),
+	}
 
 	err := helpers.ValidateInputParameters(input, &parsedInput, "summarize_context")
 	if err != nil {
@@ -131,16 +116,104 @@ func summarizeContext(input any, integration any) ([]any, error) {
 	assertedIntegration := integration.(OpenaiIntegration)
 
 	fmt.Printf("###\nExecuting OpenAi integration function...\n")
+
+	contextBytes := []byte(parsedInput.Context)
+
+	err = json.Unmarshal(contextBytes, &alertContext)
+	if err != nil {
+		return output, fmt.Errorf("error parsing input alert context: %v", err)
+	}
+
+	for _, contextValue := range alertContext.AdditionalContext {
+		for _, partialContext := range contextValue.([]any) {
+			tags, ok := partialContext.(map[string]any)["tags"].([]any)
+			if !ok {
+				continue
+			}
+			mainTag := tags[0].(string)
+			switch mainTag {
+			case "metadata":
+				fmt.Printf("Metadata found %v", partialContext)
+				tagContextGroups["metadata"] = append(tagContextGroups["metadata"], partialContext.(map[string]any))
+			case "code":
+				fmt.Printf("Code found %v", partialContext)
+				tagContextGroups["code"] = append(tagContextGroups["code"], partialContext.(map[string]any))
+			case "logs":
+				tagContextGroups["logs"] = append(tagContextGroups["logs"], partialContext.(map[string]any))
+			case "alerts":
+				fmt.Printf("Alert found %v", partialContext)
+				id, ok := partialContext.(map[string]any)["alertId"].(string)
+				if !ok {
+					fmt.Printf("Error parsing alert id: %v", err)
+					continue
+				}
+				alert, err := db.GetEnrichedAlertById(id, context.Background(), assertedIntegration.Inventory.AlertsCollection)
+				if err != nil {
+					fmt.Printf("Error getting alert by id: %v", err)
+					continue
+				}
+				partialContext.(map[string]any)["additional_context"] = alert.AdditionalContext
+				tagContextGroups["alerts"] = append(tagContextGroups["alerts"], partialContext.(map[string]any))
+			}
+		}
+	}
+
 	model := assertedIntegration.Model
 	apiKey := assertedIntegration.ApiKey
-	prompt := fmt.Sprintf(`You are on-call engineer Based on the full context from the investigation summarize investigation context for other engineers.
-		Response must contain one short paragraph of explanation of the probable root causes in full sentences. Try to correlate different context for an holistic overview.
-		The full issue context: %s`, parsedInput.Context)
+
+	if len(tagContextGroups["code"]) == 0 {
+		delete(tagContextGroups, "code")
+	}
+	if len(tagContextGroups["logs"]) == 0 {
+		delete(tagContextGroups, "logs")
+	}
+	if len(tagContextGroups["alerts"]) == 0 {
+		delete(tagContextGroups, "alerts")
+	}
+	if len(tagContextGroups["metadata"]) == 0 {
+		delete(tagContextGroups, "metadata")
+	}
+
+	if len(tagContextGroups) == 0 {
+		return output, fmt.Errorf("no context found")
+	}
+
+	for contextKey, contextGroup := range tagContextGroups {
+
+		jsonifiedContextGroup, err := json.Marshal(contextGroup)
+		if err != nil {
+			return output, fmt.Errorf("error parsing context group: %v", err)
+		}
+
+		prompt := fmt.Sprintf(`You are principal on-call engineer. 
+		Based on these %s, draw some initial conclusions about the system and it's state and summarize the context for other engineers.
+		It must fit in one paragraph.
+		If you cannot draw any tangible conclusions, you must state that by saying "Not enough context" and just this.
+		%s: %s`, contextKey, contextKey, jsonifiedContextGroup)
+
+		localSum, err := callOpenAiApi(prompt, model, apiKey)
+		if err != nil {
+			return output, err
+		}
+
+		if strings.Contains(localSum, "Not enough context") {
+			continue
+		}
+
+		partialSummaries = append(partialSummaries, localSum)
+
+	}
+
+	prompt := fmt.Sprintf(`You are a principal on-call engineer Based on the full context from the investigation summarize investigation context for other engineers.
+		Response must contain one short paragraph of explanation of the probable root causes in full sentences. Try to correlate different contexts for an holistic overview.
+		If you cannot draw any tangible conclusions, you must state that and give a reason.
+		The full issue context and some initial reasoning: %s`, strings.Join(partialSummaries, "\n---"))
 
 	summary, err := callOpenAiApi(prompt, model, apiKey)
 	if err != nil {
 		return output, err
 	}
+	fmt.Printf("Prompt %s ||||||||||||||||||||||||||||| Summary %s", prompt, summary)
 
 	output = append(output, map[string]any{
 		"summary": summary,

--- a/backend/pkg/integrations/opensearch/opensearch_integration.go
+++ b/backend/pkg/integrations/opensearch/opensearch_integration.go
@@ -245,7 +245,5 @@ func getLogOccurrences(input any, integration any) ([]any, error) {
 		outputElement.(map[string]any)["output_source"] = parsedInput.Service
 	}
 
-	fmt.Printf("###\n RAW OUTPUT OPENSEARCH: %v\n, BEFORE PROCESSING %v\n", output, allLogObjects)
-
 	return output, nil
 }

--- a/backend/pkg/integrations/signal0ne/signal0ne_integration.go
+++ b/backend/pkg/integrations/signal0ne/signal0ne_integration.go
@@ -241,6 +241,7 @@ func createIncident(input any, integration any) ([]any, error) {
 			Items:    make([]models.Item, 0),
 			Priority: si,
 			TaskName: step.DisplayName,
+			Comments: make([]models.Comment, 0),
 		}
 
 		for _, stepOutput := range stepOutputs {
@@ -321,6 +322,7 @@ func createIncident(input any, integration any) ([]any, error) {
 			IsDone:   true,
 			Items:    items,
 			Priority: len(tasks),
+			Comments: make([]models.Comment, 0),
 			TaskName: "Manually Correlated Alerts via Slack Integration",
 		}
 		incident.Tasks = append(incident.Tasks, task)

--- a/backend/pkg/integrations/signal0ne/signal0ne_integration.go
+++ b/backend/pkg/integrations/signal0ne/signal0ne_integration.go
@@ -200,12 +200,6 @@ func correlateOngoingAlerts(input any, integration any) ([]any, error) {
 			"dependency_map": parsedInput.DependencyMap,
 		})
 	}
-	fmt.Printf("\n##Time range: %v - %v\n##Services: %v\n##Alerts len: %v\n \n##Output: %v\n",
-		endTime,
-		startTime,
-		services,
-		len(alerts),
-		output)
 	return output, nil
 }
 

--- a/backend/pkg/integrations/signal0ne/signal0ne_integration.go
+++ b/backend/pkg/integrations/signal0ne/signal0ne_integration.go
@@ -137,7 +137,6 @@ func correlateOngoingAlerts(input any, integration any) ([]any, error) {
 		services[si] = strings.TrimPrefix(service, prefix)
 	}
 
-	// Pre-filtering by start time +- lookback
 	startTime, err := time.Parse(time.RFC3339, parsedInput.StartTimestamp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse start time: %v", err)
@@ -160,6 +159,9 @@ func correlateOngoingAlerts(input any, integration any) ([]any, error) {
 
 	endTime := startTime.Add(delta)
 
+	fmt.Printf(("\n##Time range: %v - %v\n"), endTime, startTime)
+	fmt.Printf("\n##Services: %v\n", services)
+
 	alerts, err := db.GetEnrichedAlertsByWorkflowId("",
 		context.Background(),
 		parsedIntegration.Inventory.AlertsCollection,
@@ -176,6 +178,8 @@ func correlateOngoingAlerts(input any, integration any) ([]any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get alerts: %v", err)
 	}
+
+	fmt.Printf("\n##Alerts len: %v\n", len(alerts))
 
 	for _, alert := range alerts {
 		output = append(output, map[string]string{
@@ -239,7 +243,6 @@ func createIncident(input any, integration any) ([]any, error) {
 				Content: make([]models.ItemContent, 0),
 				Source:  step.Integration,
 			}
-			fmt.Printf("\nStep output %s_%s %v", step.Integration, step.Name, stepOutput)
 			var parsedValue string
 			for key, value := range stepOutput.(map[string]any) {
 				_, isString := value.(string)

--- a/backend/pkg/integrations/signal0ne/signal0ne_integration.go
+++ b/backend/pkg/integrations/signal0ne/signal0ne_integration.go
@@ -186,21 +186,26 @@ func correlateOngoingAlerts(input any, integration any) ([]any, error) {
 		return nil, fmt.Errorf("failed to get alerts: %v", err)
 	}
 
-	fmt.Printf("\n##Time range: %v - %v\n##Services: %v\n##Alerts len: %v\n",
+	for _, alert := range alerts {
+		output = append(output, map[string]any{
+			"alertId":        alert.Id.Hex(),
+			"service":        alert.Service,
+			"state":          string(alert.State),
+			"name":           alert.AlertName,
+			"dependency_map": parsedInput.DependencyMap,
+		})
+	}
+	if len(output) == 0 {
+		output = append(output, map[string]any{
+			"dependency_map": parsedInput.DependencyMap,
+		})
+	}
+	fmt.Printf("\n##Time range: %v - %v\n##Services: %v\n##Alerts len: %v\n \n##Output: %v\n",
 		endTime,
 		startTime,
 		services,
-		len(alerts))
-
-	for _, alert := range alerts {
-		output = append(output, map[string]string{
-			"alertId": alert.Id.Hex(),
-			"service": alert.Service,
-			"state":   string(alert.State),
-			"name":    alert.AlertName,
-		})
-	}
-
+		len(alerts),
+		output)
 	return output, nil
 }
 

--- a/backend/scripts/python_interface/get_log_occurrences.py
+++ b/backend/scripts/python_interface/get_log_occurrences.py
@@ -9,6 +9,9 @@ enc = CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2', default_activation_fu
 def log_occurrences(collectedLogs: list, comparedFields: list) -> list:
     unique_logs_list = []
 
+    if len(collectedLogs) == 0:
+        return unique_logs_list
+    
     for log in collectedLogs:
         new = True
         incoming_log_object = {

--- a/backend/scripts/slackapp/handlers/details.py
+++ b/backend/scripts/slackapp/handlers/details.py
@@ -19,7 +19,7 @@ def handle(ack: Ack, respond: Respond, command):
     tags = command_params[1:]
     
     try:
-        data = get_enriched_alert_by_id(alert_id)
+        data = get_enriched_alert_by_id(alert_id, tags[0])
         for k,v in dict(data)["additionalContext"].items():
             if not v:
                 continue

--- a/backend/scripts/slackapp/handlers/details.py
+++ b/backend/scripts/slackapp/handlers/details.py
@@ -41,8 +41,10 @@ def handle(ack: Ack, respond: Respond, command):
         respond("An error occurred while fetching the alert details. Please try again later.")
 
 
-    
-    respond({
-        "response_type": "in_channel",
-        "blocks": blocks
-    })
+    if not blocks:
+        respond(f"No data found for the following alert[{alert_id}] and tags[{tags}].")
+    else:  
+        respond({
+            "response_type": "in_channel",
+            "blocks": blocks
+        })

--- a/backend/scripts/slackapp/handlers/details.py
+++ b/backend/scripts/slackapp/handlers/details.py
@@ -2,6 +2,9 @@ from slack_bolt import Ack, Respond
 import requests
 from handlers.helpers import get_enriched_alert_by_id
 
+
+IGNORED_FIELDS = ["tags", "dependency_map"]
+
 def handle(ack: Ack, respond: Respond, command):
     ack()
     blocks = []
@@ -22,11 +25,15 @@ def handle(ack: Ack, respond: Respond, command):
                 continue
             for item in v:
                 if any(tag in list(item["tags"]) for tag in tags):
+                    item_markdown = ""
+                    for k, v in item.items():
+                        if v != None and k not in IGNORED_FIELDS:
+                            item_markdown += f"*{k}:*\n```{v}```\n"
                     blocks.append({
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": f"*{k}:*\n```{item}```"
+                            "text": f"*{k}:*\n{item_markdown}"
                         }
                     })
     except requests.RequestException as e:

--- a/backend/scripts/slackapp/handlers/helpers.py
+++ b/backend/scripts/slackapp/handlers/helpers.py
@@ -10,8 +10,8 @@ BACKEND_URL = os.getenv("BACKEND_URL")
 BACKEND_AUTH_TOKEN = os.getenv("BACKEND_AUTH_TOKEN")
 NAMESPACE_ID = os.getenv("ORG_NAMESPACE_ID")
     
-def get_enriched_alert_by_id(alert_id):
-    url = f"{BACKEND_URL}/api/{NAMESPACE_ID}/alert/{alert_id}"
+def get_enriched_alert_by_id(alert_id, commandFilter):
+    url = f"{BACKEND_URL}/api/{NAMESPACE_ID}/alert/{alert_id}?commandFilter={commandFilter}"
     headers = {
         "Authorization": f"Bearer {BACKEND_AUTH_TOKEN}"
     }

--- a/backend/scripts/slackapp/handlers/incident.py
+++ b/backend/scripts/slackapp/handlers/incident.py
@@ -30,10 +30,10 @@ def handle_create(ack: Ack, respond: Respond, command):
             "text": {
                 "type": "mrkdwn",
                 "text": f"""*Id:* {incident['id']}\n
-                        *Name:* {incident['name']}\n
-                        *Status:* {incident['status']}\n
-                        *Severity:* {incident['severity']}\n
-                        *Link:* {incident['url']}"""
+*Name:* {incident['name']}\n
+*Status:* {incident['status']}\n
+*Severity:* {incident['severity']}\n
+*Link:* {incident['url']}"""
             }
         })
     except requests.RequestException as e:

--- a/backend/scripts/slackapp/handlers/incident.py
+++ b/backend/scripts/slackapp/handlers/incident.py
@@ -1,6 +1,6 @@
 from slack_bolt import Ack, Respond
 import requests
-from handlers.helpers import get_enriched_alert_by_id, create_incident
+from handlers.helpers import create_incident
 
 def handle_create(ack: Ack, respond: Respond, command):
     ack()
@@ -14,9 +14,6 @@ def handle_create(ack: Ack, respond: Respond, command):
     
     incident_destination = command_params[0]
     alert_ids = command_params[1:]
-
-    print("ALERT IDS", alert_ids)
-    print("INCIDENT DESTINATION", incident_destination)
 
     try:
         incident_creation_response = create_incident(incident_destination, alert_ids)

--- a/examples/ErrorRateByService.yaml
+++ b/examples/ErrorRateByService.yaml
@@ -42,11 +42,11 @@ steps:
     service: "{{.Service}}"
     tags: "{\"error\":\"true\"}"
     query: "&start={{date .TriggerProperties.timestamp \"-0m\" \"ts\"}}&lookback=15m&maxDuration&minDuration"
-    compare_by: "logs.exception.stacktrace, tags.grpc.error_message"
+    compare_by: "logs.exception.stacktrace, tags.grpc.error_message, logs.exception.message"
   output:
     output_source: "output_source"
     count: "count"
-    log: "logs.exception.stacktrace, tags.grpc.error_message"
+    log: "logs.exception.stacktrace, tags.grpc.error_message, logs.exception.message"
   condition: "{{if eq (len .AdditionalContext.opensearch_get_relevant_logs) 0}}true{{else}}false{{end}}"
 - displayName: Compare traces
   name: compare_traces

--- a/examples/ErrorRateByService.yaml
+++ b/examples/ErrorRateByService.yaml
@@ -55,14 +55,11 @@ steps:
   input:
     service: "{{.Service}}"
     operation: "{{ default .TriggerProperties.span \"all\"}}"
-    baseTraceTags: "{\"rpc.grpc.status_code\":\"0\"},{\"http.status_code\":\"200\"}"
-    comparedTraceTags: "{\"error\":\"true\"}"
-    baseTraceQuery: "&start={{date .TriggerProperties.timestamp \"-0m\" \"ts\"}}&lookback=30m&maxDuration&minDuration"
-    comparedTraceQuery: "&start={{date .TriggerProperties.timestamp \"-0m\" \"ts\"}}&lookback=15m&maxDuration&minDuration"
+    traceTags: "{\"error\":\"true\"}"
+    traceQuery: "&start={{date .TriggerProperties.timestamp \"-0m\" \"ts\"}}&lookback=15m&maxDuration&minDuration"
   output:
     output_source: "output_source"
     operation: "operation"
-    processes_diff: "processes"
     dependency_map: "dependency_map"
 - displayName: Get relevant alerts
   name: correlate_ongoing_alerts

--- a/examples/ErrorRateByService.yaml
+++ b/examples/ErrorRateByService.yaml
@@ -16,18 +16,18 @@ steps:
   integration: backstage
   function: get_properties_values
   input:
-    filter: kind=component,metadata.name={{.service}}
+    filter: kind=component,metadata.name={{.Service}}
   output:
     owner: "spec.owner"
     slack_channel: "metadata.labels.slack_channel"
-    repo_uri: "metadata.labels.repo_uri"
+    repo_name: "metadata.labels.repo_name"
 - displayName: Get relevant logs
   name: get_relevant_logs
   integration: opensearch
   function: get_log_occurrences
   input:
-    service: "{{.service}}"
-    query: "{\"query\": {\"bool\": {\"must\": [{\"match\": {\"resource.service.name\": \"{{.service}}\"}},{\"range\": {\"@timestamp\": {\"gte\": \"{{date .TriggerProperties.timestamp \"-15m\" \"rfc\"}}\",\"lte\": \"{{date .TriggerProperties.timestamp \"+15m\" \"rfc\"}}\"}}}],\"must_not\": [{\"match\": {\"severity.text\": \"INFO\"}},{\"match\": {\"severity.text\": \"Information\"}}]}}}"
+    service: "{{.Service}}"
+    query: "{\"query\": {\"bool\": {\"must\": [{\"match\": {\"resource.service.name\": \"{{.Service}}\"}},{\"range\": {\"@timestamp\": {\"gte\": \"{{date .TriggerProperties.timestamp \"-15m\" \"rfc\"}}\",\"lte\": \"{{date .TriggerProperties.timestamp \"+15m\" \"rfc\"}}\"}}}],\"must_not\": [{\"match\": {\"severity.text\": \"INFO\"}},{\"match\": {\"severity.text\": \"Information\"}}]}}}"
     compare_by: "body, resource.host.name"
   output:
     output_source: "output_source"
@@ -39,7 +39,7 @@ steps:
   integration: jaeger
   function: get_properties_values
   input:
-    service: "{{.service}}"
+    service: "{{.Service}}"
     tags: "{\"error\":\"true\"}"
     query: "&start={{date .TriggerProperties.timestamp \"-0m\" \"ts\"}}&lookback=15m&maxDuration&minDuration"
     compare_by: "logs.exception.stacktrace, tags.grpc.error_message"
@@ -53,7 +53,7 @@ steps:
   integration: jaeger
   function: compare_traces
   input:
-    service: "{{.service}}"
+    service: "{{.Service}}"
     operation: "{{ default .TriggerProperties.span \"all\"}}"
     baseTraceTags: "{\"rpc.grpc.status_code\":\"0\"},{\"http.status_code\":\"200\"}"
     comparedTraceTags: "{\"error\":\"true\"}"
@@ -69,11 +69,31 @@ steps:
   integration: signal0ne
   function: correlate_ongoing_alerts
   input:
-    startTimestamp: "{{date .startTime \"-0m\" \"rfc\"}}"
+    startTimestamp: "{{date .TriggerProperties.timestamp \"-0m\" \"rfc\"}}"
     dependency_map: "{{range .AdditionalContext.jaeger_compare_traces}}{{.dependency_map}},{{end}}"
   output:
     ongoing_alerts: "ongoing_alerts"
-- displayName: Summarize issue content
+- displayName: Get latest GH action run
+  name: get_latest_gh_action_run
+  integration: github
+  function: inspect_github_actions
+  input:
+    action_name: "Deploy to Remote Server"
+    repo_name: "{{index .AdditionalContext.backstage_get_ownership 0 \"repo_name\"}}"
+    branch_name: "main"
+  output:
+    commitId: "commit"
+    status: "status"
+- displayName: Get code diff
+  name: get_code_diff
+  integration: github
+  function: get_commit_diff
+  input:
+    repo_name: "{{index .AdditionalContext.backstage_get_ownership 0 \"repo_name\"}}"
+    commit: "{{index .AdditionalContext.github_get_latest_gh_action_run 0 \"commitId\"}}"
+  output:
+    diff: "diff"
+- displayName: Summarize whole context
   name: summarize_issue_content
   integration: openai
   function: summarize_context
@@ -88,5 +108,5 @@ steps:
   input:
     slack_channel: "{{range .AdditionalContext.backstage_get_ownership}}{{.slack_channel}},{{end}}"
     parsable_context_object: "{{root}}"
-    additional_message_payload: "{\"service\": \"{{.service}}\"}"
+    additional_message_payload: "{\"service\": \"{{.Service}}\"}"
 

--- a/examples/ErrorRateByService.yaml
+++ b/examples/ErrorRateByService.yaml
@@ -4,8 +4,8 @@ lookback: 15m
 trigger:
   webhook:
     integration: alertmanager
+    service: "labels.job"
     output:
-      service: "job"
       alertname: "labels.alertname"
       span: "span_name"
       timestamp: "startsAt"
@@ -16,17 +16,18 @@ steps:
   integration: backstage
   function: get_properties_values
   input:
-    filter: kind=component,metadata.name={{.TriggerProperties.service}}
+    filter: kind=component,metadata.name={{.service}}
   output:
     owner: "spec.owner"
     slack_channel: "metadata.labels.slack_channel"
+    repo_uri: "metadata.labels.repo_uri"
 - displayName: Get relevant logs
   name: get_relevant_logs
   integration: opensearch
   function: get_log_occurrences
   input:
-    service: "{{.TriggerProperties.service}}"
-    query: "{\"query\": {\"bool\": {\"must\": [{\"match\": {\"resource.service.name\": \"{{.TriggerProperties.service}}\"}},{\"range\": {\"@timestamp\": {\"gte\": \"{{date .TriggerProperties.timestamp \"-15m\" \"rfc\"}}\",\"lte\": \"{{date .TriggerProperties.timestamp \"+15m\" \"rfc\"}}\"}}}],\"must_not\": [{\"match\": {\"severity.text\": \"INFO\"}},{\"match\": {\"severity.text\": \"Information\"}}]}}}"
+    service: "{{.service}}"
+    query: "{\"query\": {\"bool\": {\"must\": [{\"match\": {\"resource.service.name\": \"{{.service}}\"}},{\"range\": {\"@timestamp\": {\"gte\": \"{{date .TriggerProperties.timestamp \"-15m\" \"rfc\"}}\",\"lte\": \"{{date .TriggerProperties.timestamp \"+15m\" \"rfc\"}}\"}}}],\"must_not\": [{\"match\": {\"severity.text\": \"INFO\"}},{\"match\": {\"severity.text\": \"Information\"}}]}}}"
     compare_by: "body, resource.host.name"
   output:
     output_source: "output_source"
@@ -38,7 +39,7 @@ steps:
   integration: jaeger
   function: get_properties_values
   input:
-    service: "{{.TriggerProperties.service}}"
+    service: "{{.service}}"
     tags: "{\"error\":\"true\"}"
     query: "&start={{date .TriggerProperties.timestamp \"-0m\" \"ts\"}}&lookback=15m&maxDuration&minDuration"
     compare_by: "logs.exception.stacktrace, tags.grpc.error_message"
@@ -52,7 +53,7 @@ steps:
   integration: jaeger
   function: compare_traces
   input:
-    service: "{{.TriggerProperties.service}}"
+    service: "{{.service}}"
     operation: "{{ default .TriggerProperties.span \"all\"}}"
     baseTraceTags: "{\"rpc.grpc.status_code\":\"0\"},{\"http.status_code\":\"200\"}"
     comparedTraceTags: "{\"error\":\"true\"}"
@@ -62,19 +63,16 @@ steps:
     output_source: "output_source"
     operation: "operation"
     processes_diff: "processes"
-    # TBD - 
-    # spans_diff:
-    # errors_diff:
-    # duration_diff: 
-- displayName: Get containers status
-  name: get_containers_status
-  integration: alertmanager
-  function: get_relevant_alerts
+    dependency_map: "dependency_map"
+- displayName: Get relevant alerts
+  name: correlate_ongoing_alerts
+  integration: signal0ne
+  function: correlate_ongoing_alerts
   input:
-    filter: "{{range .AdditionalContext.jaeger_compare_traces}}name={{.processes_diff.processName}},{{end}}"
+    startTimestamp: "{{date .startTime \"-0m\" \"rfc\"}}"
+    dependency_map: "{{range .AdditionalContext.jaeger_compare_traces}}{{.dependency_map}},{{end}}"
   output:
-    output_source: "output_source"
-    alert: "alert"
+    ongoing_alerts: "ongoing_alerts"
 - displayName: Summarize issue content
   name: summarize_issue_content
   integration: openai
@@ -90,5 +88,5 @@ steps:
   input:
     slack_channel: "{{range .AdditionalContext.backstage_get_ownership}}{{.slack_channel}},{{end}}"
     parsable_context_object: "{{root}}"
-    additional_message_payload: "{\"service\": \"{{.TriggerProperties.service}}\"}"
+    additional_message_payload: "{\"service\": \"{{.service}}\"}"
 

--- a/examples/ErrorRateByService.yaml
+++ b/examples/ErrorRateByService.yaml
@@ -42,24 +42,19 @@ steps:
     service: "{{.Service}}"
     tags: "{\"error\":\"true\"}"
     query: "&start={{date .TriggerProperties.timestamp \"-0m\" \"ts\"}}&lookback=15m&maxDuration&minDuration"
-    compare_by: "logs.exception.stacktrace, tags.grpc.error_message, logs.exception.message"
+    compare_by: "logs.exception.stacktrace, tags.grpc.error_message, logs.exception.message, tags.otel.status_description"
   output:
     output_source: "output_source"
     count: "count"
-    log: "logs.exception.stacktrace, tags.grpc.error_message, logs.exception.message"
+    log: "logs.exception.stacktrace, tags.grpc.error_message, logs.exception.message, tags.otel.status_description"
   condition: "{{if eq (len .AdditionalContext.opensearch_get_relevant_logs) 0}}true{{else}}false{{end}}"
-- displayName: Compare traces
-  name: compare_traces
+- displayName: Get dependency map
+  name: get_dependencies
   integration: jaeger
-  function: compare_traces
+  function: get_dependencies
   input:
     service: "{{.Service}}"
-    operation: "{{ default .TriggerProperties.span \"all\"}}"
-    traceTags: "{\"error\":\"true\"}"
-    traceQuery: "&start={{date .TriggerProperties.timestamp \"-0m\" \"ts\"}}&lookback=15m&maxDuration&minDuration"
   output:
-    output_source: "output_source"
-    operation: "operation"
     dependency_map: "dependency_map"
 - displayName: Get relevant alerts
   name: correlate_ongoing_alerts
@@ -67,7 +62,7 @@ steps:
   function: correlate_ongoing_alerts
   input:
     startTimestamp: "{{date .TriggerProperties.timestamp \"-0m\" \"rfc\"}}"
-    dependency_map: "{{range .AdditionalContext.jaeger_compare_traces}}{{.dependency_map}},{{end}}"
+    dependency_map: "{{index .AdditionalContext.jaeger_get_dependencies 0 \"dependency_map\"}}"
   output:
     alertId: "alertId"
     service: "service"

--- a/examples/ErrorRateByService.yaml
+++ b/examples/ErrorRateByService.yaml
@@ -69,7 +69,11 @@ steps:
     startTimestamp: "{{date .TriggerProperties.timestamp \"-0m\" \"rfc\"}}"
     dependency_map: "{{range .AdditionalContext.jaeger_compare_traces}}{{.dependency_map}},{{end}}"
   output:
-    ongoing_alerts: "ongoing_alerts"
+    alertId: "alertId"
+    service: "service"
+    state: "state"
+    name: "name"
+    dependency_map: "dependency_map"
 - displayName: Get latest GH action run
   name: get_latest_gh_action_run
   integration: github


### PR DESCRIPTION
 - LICENSE from MIT template
 - Correlated alerts refresh (due to dynamic nature) on getAlerts
 - more verbose execution history with logs for easier debugging 
 - stabilized parameters passing to functions from flow
 - GitHub: get deployed commit, get diff for further analysis
 - Jaeger: replace "compare traces" with building service map based on traces (less error prone + better for future use)
 - Slack: more readable output